### PR TITLE
Remove web3 functionality from dashboard UI

### DIFF
--- a/app/components/form-builder/FormBuilder.tsx
+++ b/app/components/form-builder/FormBuilder.tsx
@@ -26,7 +26,6 @@ import {
 } from "@/components/ui/breadcrumb";
 import { ChevronRight, Home } from "lucide-react";
 import { EditFormDialog } from "./EditFormDialog";
-import { Web3Dialog } from "../forms/Web3Dialog";
 import { ManageCollaboratorsDialog } from "./ManageCollaboratorsDialog";
 
 export function FormBuilder({ formId }: { formId: string }) {
@@ -337,25 +336,6 @@ export function FormBuilder({ formId }: { formId: string }) {
               )}
               {formId !== "new" && formData && (
                 <>
-                  <Web3Dialog
-                    form={{
-                      id: parseInt(formId),
-                      title: state.title,
-                      description: state.description,
-                      elements: state.elements,
-                      settings: state.settings,
-                      isPublished,
-                      userId: user?.id || "",
-                      createdAt: formData.createdAt,
-                      updatedAt: formData.updatedAt,
-                      customSlug: formData.customSlug,
-                      metaTitle: formData.metaTitle || state.title,
-                      metaDescription:
-                        formData.metaDescription || state.description,
-                      socialImageUrl: formData.socialImageUrl,
-                    }}
-                    onUpdate={handleFormUpdate}
-                  />
                   <ShareDialog
                     form={{
                       id: parseInt(formId),

--- a/app/components/forms/FormContent.tsx
+++ b/app/components/forms/FormContent.tsx
@@ -25,11 +25,8 @@ interface FormContentProps {
   responses: Record<string, FormElementValue>;
   isSubmitting: boolean;
   isSuccess: boolean;
-  isRewardPending: boolean;
-  showRewardSuccess: boolean;
   height: string;
   isMobile: boolean;
-  chainId: number;
   handleNext: () => void;
   handlePrevious: () => void;
   handleSubmit: () => void;
@@ -48,11 +45,8 @@ export function FormContent({
   responses,
   isSubmitting,
   isSuccess,
-  isRewardPending,
-  showRewardSuccess,
   height,
   isMobile,
-  chainId,
   handleNext,
   handlePrevious,
   handleSubmit,
@@ -93,15 +87,11 @@ export function FormContent({
       <FormLoadingState
         isSubmitting={isSubmitting}
         isSuccess={isSuccess}
-        isRewardPending={isRewardPending}
-        showRewardSuccess={showRewardSuccess}
       />
 
       <FormSubmissionFeedback
         isSubmitting={isSubmitting}
         isSuccess={isSuccess}
-        isRewardPending={isRewardPending}
-        showRewardSuccess={showRewardSuccess}
       />
 
       <motion.div
@@ -189,8 +179,6 @@ export function FormContent({
                     isLastElement={isLastElement}
                     isMobile={isMobile}
                     isSubmitting={isSubmitting}
-                    isRewardPending={isRewardPending}
-                    chainId={chainId}
                     form={form}
                     onNext={handleNext}
                     onPrevious={handlePrevious}

--- a/app/components/forms/FormLoadingState.tsx
+++ b/app/components/forms/FormLoadingState.tsx
@@ -4,15 +4,11 @@ import { Loader2, CheckCircle2 } from "lucide-react";
 interface FormLoadingStateProps {
   isSubmitting: boolean;
   isSuccess: boolean;
-  isRewardPending: boolean;
-  showRewardSuccess: boolean;
 }
 
 export function FormLoadingState({
   isSubmitting,
   isSuccess,
-  isRewardPending,
-  showRewardSuccess,
 }: FormLoadingStateProps) {
   if (isSubmitting && !isSuccess) {
     return (
@@ -28,9 +24,7 @@ export function FormLoadingState({
         >
           <Loader2 className="h-12 w-12 animate-spin text-primary mx-auto mb-4" />
           <h3 className="text-2xl font-semibold">
-            {isRewardPending
-              ? "Processing reward..."
-              : "Submitting your response..."}
+            Submitting your response...
           </h3>
         </motion.div>
       </motion.div>
@@ -69,9 +63,7 @@ export function FormLoadingState({
           </motion.div>
           <h3 className="text-2xl font-semibold">Response submitted!</h3>
           <p className="text-muted-foreground mt-2">
-            {showRewardSuccess
-              ? "Your reward is being processed..."
-              : "Thank you for your time."}
+            Thank you for your time.
           </p>
         </motion.div>
       </motion.div>

--- a/app/components/forms/FormNavigationButtons.tsx
+++ b/app/components/forms/FormNavigationButtons.tsx
@@ -1,7 +1,6 @@
 import { Button } from "@/components/ui/button";
 import { ChevronLeft } from "lucide-react";
 import { Form } from "@/types/form";
-import { baseSepolia } from "viem/chains";
 import { cn } from "@/lib/utils";
 
 interface FormNavigationButtonsProps {
@@ -9,14 +8,12 @@ interface FormNavigationButtonsProps {
   isLastElement: boolean;
   isMobile: boolean;
   isSubmitting: boolean;
-  isRewardPending: boolean;
-  chainId: number;
   form: Form;
   onNext: () => void;
   onPrevious: () => void;
   onSubmit: () => void;
   theme: Form["settings"]["theme"];
-  hasError?: boolean; // Add hasError prop
+  hasError?: boolean;
 }
 
 export function FormNavigationButtons({
@@ -24,9 +21,6 @@ export function FormNavigationButtons({
   isLastElement,
   isMobile,
   isSubmitting,
-  isRewardPending,
-  chainId,
-  form,
   onNext,
   onPrevious,
   onSubmit,
@@ -156,12 +150,12 @@ export function FormNavigationButtons({
           id="submit-button"
           className={cn(
             "ml-auto",
-            (isSubmitting || isRewardPending) && "opacity-70",
+            isSubmitting && "opacity-70",
             hasError && "animate-pulse"
           )}
           style={{
             ...errorButtonStyles,
-            ...(isSubmitting || isRewardPending
+            ...(isSubmitting
               ? {
                   backgroundColor: `${theme.primaryColor}99`,
                 }
@@ -169,18 +163,13 @@ export function FormNavigationButtons({
           }}
           onClick={handleSubmitClick}
           size="lg"
-          disabled={isSubmitting || isRewardPending}
+          disabled={isSubmitting}
         >
-          {isRewardPending
-            ? "Processing Reward..."
-            : isSubmitting
-              ? "Submitting..."
-              : chainId !== baseSepolia.id &&
-                  form.settings.web3?.rewards.enabled
-                ? "Switch Network & Submit"
-                : hasError
-                  ? "Please Fill Required Field"
-                  : "Submit"}
+          {isSubmitting
+            ? "Submitting..."
+            : hasError
+              ? "Please Fill Required Field"
+              : "Submit"}
         </Button>
       )}
     </div>

--- a/app/components/forms/FormSubmissionFeedback.tsx
+++ b/app/components/forms/FormSubmissionFeedback.tsx
@@ -5,15 +5,11 @@ import { motion } from "motion/react";
 interface FormSubmissionFeedbackProps {
   isSubmitting: boolean;
   isSuccess: boolean;
-  isRewardPending: boolean;
-  showRewardSuccess: boolean;
 }
 
 export function FormSubmissionFeedback({
   isSubmitting,
   isSuccess,
-  isRewardPending,
-  showRewardSuccess,
 }: FormSubmissionFeedbackProps) {
   if (isSubmitting && !isSuccess) {
     return (
@@ -29,15 +25,8 @@ export function FormSubmissionFeedback({
         >
           <Loader2 className="h-12 w-12 animate-spin text-primary mx-auto mb-4" />
           <h3 className="text-2xl font-semibold">
-            {isRewardPending
-              ? "Sending reward..."
-              : "Submitting your response..."}
+            Submitting your response...
           </h3>
-          {isRewardPending && (
-            <p className="text-muted-foreground mt-2">
-              Please confirm the transaction in your wallet
-            </p>
-          )}
         </motion.div>
       </motion.div>
     );
@@ -75,9 +64,7 @@ export function FormSubmissionFeedback({
           </motion.div>
           <h3 className="text-2xl font-semibold">Response submitted!</h3>
           <p className="text-muted-foreground mt-2">
-            {showRewardSuccess
-              ? "Reward has been sent to your wallet."
-              : "Thank you for your time."}
+            Thank you for your time.
           </p>
         </motion.div>
       </motion.div>

--- a/app/context/form-context.tsx
+++ b/app/context/form-context.tsx
@@ -1,12 +1,5 @@
-import {
-  createContext,
-  useContext,
-  useReducer,
-  ReactNode,
-  useEffect,
-} from "react";
+import { createContext, useContext, useReducer, ReactNode } from "react";
 import { Form, FormElement, FormElementProperties } from "@/types/form";
-import { useAccount } from "wagmi";
 import { FormTemplate } from "@/db/schema";
 
 /**
@@ -25,7 +18,6 @@ type FormState = {
   description: string | null;
   /** Form settings like theme, behavior, etc. */
   settings: Form["settings"];
-  connectedAddress?: string;
 };
 
 /**
@@ -68,11 +60,6 @@ type FormAction =
     }
   /** Updates form settings */
   | { type: "UPDATE_SETTINGS"; payload: Partial<Form["settings"]> }
-  | {
-      type: "UPDATE_WEB3_SETTINGS";
-      payload: NonNullable<Form["settings"]["web3"]>;
-    }
-  | { type: "SET_CONNECTED_ADDRESS"; payload: string | undefined }
   | { type: "CREATE_FROM_TEMPLATE"; payload: FormTemplate }
   | {
       type: "SAVE_AS_TEMPLATE";
@@ -209,21 +196,6 @@ function formReducer(state: FormState, action: FormAction): FormState {
         settings: { ...state.settings, ...action.payload },
       };
 
-    case "UPDATE_WEB3_SETTINGS":
-      return {
-        ...state,
-        settings: {
-          ...state.settings,
-          web3: action.payload,
-        },
-      };
-
-    case "SET_CONNECTED_ADDRESS":
-      return {
-        ...state,
-        connectedAddress: action.payload,
-      };
-
     case "CREATE_FROM_TEMPLATE":
       return {
         ...state,
@@ -258,11 +230,7 @@ const FormContext = createContext<{
 export function FormProvider({ children }: { children: ReactNode }) {
   // useReducer gives us the current state and a dispatch function to update it
   const [state, dispatch] = useReducer(formReducer, initialState);
-  const { address } = useAccount();
 
-  useEffect(() => {
-    dispatch({ type: "SET_CONNECTED_ADDRESS", payload: address });
-  }, [address]);
   return (
     <FormContext.Provider value={{ state, dispatch }}>
       {children}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,7 +3,6 @@ import { ClerkProvider } from "@clerk/nextjs";
 import localFont from "next/font/local";
 import "./globals.css";
 import { Toaster } from "@/components/ui/toaster";
-import { Web3Provider } from "./components/providers/web3-provider";
 
 const geistSans = localFont({
   src: "./fonts/GeistVF.woff",
@@ -67,18 +66,16 @@ export default function RootLayout({
 }>) {
   return (
     <ClerkProvider>
-      <Web3Provider>
-        <html lang="en">
-          <body
-            className={`${geistSans.variable} ${geistMono.variable} antialiased`}
-          >
-            <main>
-              {children}
-              <Toaster />
-            </main>
-          </body>
-        </html>
-      </Web3Provider>
+      <html lang="en">
+        <body
+          className={`${geistSans.variable} ${geistMono.variable} antialiased`}
+        >
+          <main>
+            {children}
+            <Toaster />
+          </main>
+        </body>
+      </html>
     </ClerkProvider>
   );
 }


### PR DESCRIPTION
## What this does
Removes all web3 functionality from the dashboard

## Changes

**Removed from UI:**
- Web3 settings dialog in form builder
- Token gating checks on form access
- Wallet connection prompts
- Reward claiming functionality
- Chain switching requirements

**Components updated:**
- FormBuilder: Removed Web3Dialog component
- FormView: Stripped out all web3 logic and token gate checks
- FormContent: Cleaned up web3-related props
- FormNavigationButtons: Simplified submit flow
- FormLoadingState & FormSubmissionFeedback: Removed reward processing states
- FormContext: Removed web3 state management

**Global changes:**
- Removed Web3Provider from app layout
- Forms now work without any web3 dependencies

## 🧠 Why

We want to simplify the user experience by removing web3 complexity from the dashboard and we feel like it's no longer needed!

## 🧪 Testing

- [ ] Form builder loads without web3 settings
- [ ] Forms can be created and submitted normally
- [ ] No wallet connection prompts appear
- [ ] No console errors related to missing web3 providers

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on removing the `Web3Provider` and related web3 functionality from various components, simplifying the form submission process, and enhancing the user experience by streamlining feedback messages.

### Detailed summary
- Removed `Web3Provider` from `app/layout.tsx`.
- Eliminated `isRewardPending` and `showRewardSuccess` props from multiple components.
- Simplified feedback messages in `FormLoadingState`, `FormSubmissionFeedback`, and `FormContent`.
- Removed web3-related checks and state management from `FormView`.
- Cleaned up the `FormContext` by removing unused actions and state related to web3.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->